### PR TITLE
chore(Dockerfile): ignore prepare script when building the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ WORKDIR /app
 
 COPY . .
 
-RUN yarn add shx -W && yarn install && yarn build
+RUN yarn add shx -W --ignore-scripts && \
+    yarn install --ignore-scripts && \
+    yarn build
 
 ###
 


### PR DESCRIPTION
Hey,
Currently the image can't be built because of the `prepare` script. We prevent from launching it in the build process of the image.
Thanks!